### PR TITLE
Add 12-hour time format and fix overflow issue in `Current_time` handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Compile yourself using `cargo build --release`
 - `--country STRING` - pass a specific city location to aladhan.com
 - `--method STRING` - pass a calculation method number. see [reference](https://aladhan.com/calculation-methods)
 - `--ar` - display date in Arabic format.
----------------------------------------------------------------------
-- `--ampm` - display time in AM/PM format ! in development
+- `--ampm` - display time in AM/PM format
 
 e.g. `prayerbar --city Brussels --country Belgium --method 15`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,13 +190,7 @@ fn format_prayerbar(
 ) {
     for (index, (prayer_name, prayer_time)) in times_vec.iter().enumerate() {
         let name = *prayer_name;
-        if name.eq("Current_time") && index <= times_vec.len() {
-            *bar_text = format!(
-                "🕋 {} {}",
-                times_vec[index + 1].0,
-                times_vec[index + 1].1.format("%H:%M")
-            );
-        } else {
+        if name != "Current_time" {
             *tooltip += format!(
                 "{}{} at {}\n",
                 icons[name],
@@ -204,6 +198,14 @@ fn format_prayerbar(
                 prayer_time.format("%H:%M")
             )
             .as_str();
+        } else if (index + 1) < times_vec.len() {
+            *bar_text = format!(
+                "🕋 {} {}",
+                times_vec[index + 1].0,
+                times_vec[index + 1].1.format("%H:%M")
+            );
+        } else {
+            *bar_text = format!("🕋 {} {}", times_vec[0].0, times_vec[0].1.format("%H:%M"));
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,8 @@ struct Args {
     method: Option<String>,
     #[arg(long, help = "display calendar in Arabic format")]
     ar: bool,
+    #[arg(long, help = "display time in AM/PM format")]
+    ampm: bool,
 }
 
 const DEFAULT_RESULT: &[(&str, &str)] = &[("text", "N/A"), ("tooltip", "N/A")];
@@ -165,7 +167,13 @@ fn parse_prayer_times<'a>(times: Value, args: &Args) -> HashMap<&'a str, String>
     prayer_data.push(("Current_time", dt.fixed_offset()));
 
     sort_prayer_times(&mut prayer_data);
-    format_prayerbar(&prayer_data, &mut tooltip, &mut text, &prayer_icons);
+    format_prayerbar(
+        &prayer_data,
+        &mut tooltip,
+        &mut text,
+        &prayer_icons,
+        args.ampm,
+    );
 
     data.insert("text", text);
     data.insert("tooltip", tooltip);
@@ -187,7 +195,10 @@ fn format_prayerbar(
     tooltip: &mut String,
     bar_text: &mut String,
     icons: &HashMap<&str, &str>,
+    is_ampm: bool,
 ) {
+    let time_format = if is_ampm { "%I:%M %p" } else { "%H:%M" };
+
     for (index, (prayer_name, prayer_time)) in times_vec.iter().enumerate() {
         let name = *prayer_name;
         if name != "Current_time" {
@@ -195,17 +206,21 @@ fn format_prayerbar(
                 "{}{} at {}\n",
                 icons[name],
                 name,
-                prayer_time.format("%H:%M")
+                prayer_time.format(time_format)
             )
             .as_str();
         } else if (index + 1) < times_vec.len() {
             *bar_text = format!(
                 "🕋 {} {}",
                 times_vec[index + 1].0,
-                times_vec[index + 1].1.format("%H:%M")
+                times_vec[index + 1].1.format(time_format)
             );
         } else {
-            *bar_text = format!("🕋 {} {}", times_vec[0].0, times_vec[0].1.format("%H:%M"));
+            *bar_text = format!(
+                "🕋 {} {}",
+                times_vec[0].0,
+                times_vec[0].1.format(time_format)
+            );
         }
     }
 }


### PR DESCRIPTION
Fix #6 

Introduce a new feature to display the time in a 12-hour format. Additionally, address the overflow issue by setting the bar to the first element when `Current_time` is the last element in the list.